### PR TITLE
Update workload-standard to v0.3.1

### DIFF
--- a/bedrock_train.hcl
+++ b/bedrock_train.hcl
@@ -2,7 +2,7 @@ version = "1.0"
 
 train {
     step features_trainer {
-        image = "basisai/workload-standard:v0.2.2"
+        image = "quay.io/basisai/workload-standard:v0.3.1"
         install = [
             "pip3 install --upgrade pip",
             "pip3 install -r requirements-train.txt",
@@ -15,7 +15,7 @@ train {
     }
 
     step train {
-        image = "basisai/workload-standard:v0.2.2"
+        image = "quay.io/basisai/workload-standard:v0.3.1"
         install = [
             "pip3 install --upgrade pip",
             "pip3 install -r requirements-train.txt",
@@ -56,7 +56,7 @@ serve {
 
 batch_score {
     step compute_shap {
-        image = "basisai/workload-standard:v0.2.2"
+        image = "quay.io/basisai/workload-standard:v0.3.1"
         install = [
             "pip3 install --upgrade pip",
             "pip3 install -r requirements-train.txt",


### PR DESCRIPTION
Updates docker image to point to quay.io, bumps workload-standard version

See PRs for changes to workload-standard

- https://github.com/basisai/docker-workload/pull/30
- https://github.com/basisai/docker-workload/pull/28

Tested to run on GCP and AWS.